### PR TITLE
Removed [sticker] from empty UFITranslatedText divs

### DIFF
--- a/chrome/styles/contentstyles.css
+++ b/chrome/styles/contentstyles.css
@@ -7,3 +7,7 @@
 .UFIImageBlockContent .UFICommentContent > div:empty::after {
     content: "[sticker]";
 }
+
+.UFITranslatedText::after {
+    content: '' !important;
+}

--- a/firefox/data/contentstyles.css
+++ b/firefox/data/contentstyles.css
@@ -7,3 +7,7 @@
 .UFIImageBlockContent .UFICommentContent > div:empty::after {
     content: "[sticker]";
 }
+
+.UFITranslatedText::after {
+    content: '' !important;
+}


### PR DESCRIPTION
Hello,

this is my first pull request so excuse me if something went wrong. I added only one rule into both chrome's and firefox's css file, to hide unnecessary [sticker] label after empty divs which are placeholders for translated text. (UFITranslatedText)

I hope it's OK, and if it's not, please let me know what I can do to have it merged in the actual FF plugin, which I like to have in my browser ever since I discovered.

Thanks,
Regards,
Zoli
